### PR TITLE
nvim: map localleader to same key as leader

### DIFF
--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -293,6 +293,7 @@ set laststatus=2
 " Keybindings
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""''
 
+let maplocalleader = " "
 let mapleader = " "
 nnoremap <SPACE> <Nop>
 


### PR DESCRIPTION
The plugin vimtex somehow needs localleader instead of leader.
Because I am rather lazy, mapping both to the same key seems appropriate at this time.

I am sure that will somehow bite me later.