### PR TITLE
shell: bash: let QT apps behave like it is a kde desktop

### DIFF
--- a/shell/.bashrc
+++ b/shell/.bashrc
@@ -13,6 +13,9 @@ export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 export LANGUAGE=en_US.UTF-8
 
+# let kde apps behave like it is a kde desktop
+export QT_QPA_PLATFORMTHEME=kde
+
 ## APPLICATION SPECIFIC EXPORTS
 
 #export TERM=screen-256color


### PR DESCRIPTION
By exporting QT_QPA_PLATFORMTHEME, Qt apps are able to read the style given by the KDE desktop environment.
This is needed for a change later down the road, where I will dismiss KDE and change into a i3 only setup.