### PR TITLE
i3: start dolphin daemon to be able to see QT_QPA_PLATFORMTHEME variable

### DIFF
--- a/i3/.config/i3/config
+++ b/i3/.config/i3/config
@@ -261,6 +261,9 @@ for_window [class="feh"] floating enable
 
 # setting background image
 exec_always feh --bg-scale ~/media/pictures/wallpaper/1428365872599.png
+# starting dolphin daemon to have it setup with the right environment
+# needed to get the right style used when starting dolphin from firefox
+exec --no-startup-id dolphin --daemon
 
 # autostarting applications, automatically assigned to workspaces because of rules above
 exec spotify


### PR DESCRIPTION
Issue was that dolphin started from other applications did not take on
the style specified by our environment.